### PR TITLE
replace float operations with fixed point

### DIFF
--- a/src/antialiasing.h
+++ b/src/antialiasing.h
@@ -1,6 +1,11 @@
+// antialiasing.h by Grégoire Sage
+// https://github.com/gregoiresage/pebble-antialiasing-lib
+
 #pragma once
 
 #include <pebble.h>
+
+#ifdef PBL_COLOR
 
 // //! Draws a 1-pixel wide line in the current stroke color with antialiasing
 // //! @param ctx The destination graphics context in which to draw
@@ -33,3 +38,9 @@ void graphics_draw_line_antialiased(GContext* ctx, GPoint p0, GPoint p1);
 //! @param path The path to fill
 //! @see \ref graphics_context_set_stroke_color()
 void gpath_draw_outline_antialiased(GContext* ctx, GPath *path);
+
+#else  //PBL_COLOR
+
+#define gpath_draw_outline_antialiased gpath_draw_outline
+
+#endif // PBL_COLOR


### PR DESCRIPTION
Hi Grégoire, here are some simple changes to replace the floating-point calculations with fixed-point arithmetic.  Since it is only a few divides and multiplies, it's an easy change.

I also replaced the incrementing of gradient with a per-pixel recomputation of intery based on the current value of x; this seemed to solve the minor precision errors I was getting with longer lines (probably aggravated by the use of fixed-point instead of true floating point).

Thanks so much for this very useful library!
